### PR TITLE
upd: upgrade grafana to 9.4.3 (CLOUD-1663)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Specific service variables:
 - `service_grafana_admin_password`: string
 - `service_grafana_client_id`: string (used for the IAM login)
 - `service_grafana_client_secret`: string (used for the IAM login)
-- `service_grafana_image`: string (default: `"dodasts/monitoring-grafana:v1.0.1-monitoring"`)
+- `service_grafana_image`: string (default: `"dodasts/monitoring-grafana:v1.0.8-monitoring"`)
 
 ### vars
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,5 +15,4 @@ service_grafana: yes
 service_grafana_port: 3000
 service_grafana_admin_user: ""
 service_grafana_admin_password: ""
-#service_grafana_image: "dodasts/monitoring-grafana:v1.0.8-monitoring"
-service_grafana_image: "mginfn/monitoring-grafana:v1.0.8-monitoring"
+service_grafana_image: "dodasts/monitoring-grafana:v1.0.8-monitoring"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,5 @@ service_grafana: yes
 service_grafana_port: 3000
 service_grafana_admin_user: ""
 service_grafana_admin_password: ""
-service_grafana_image: "dodasts/monitoring-grafana:v1.0.3-monitoring"
+#service_grafana_image: "dodasts/monitoring-grafana:v1.0.8-monitoring"
+service_grafana_image: "mginfn/monitoring-grafana:v1.0.8-monitoring"


### PR DESCRIPTION
Aggiornato il valore di default di service_grafana_image.
Creare tag v1.2.3.